### PR TITLE
Permit user to reduce retention to 1 day using settings

### DIFF
--- a/xdrip/Constants/ConstantsHousekeeping.swift
+++ b/xdrip/Constants/ConstantsHousekeeping.swift
@@ -3,7 +3,7 @@ import Foundation
 enum ConstantsHousekeeping {
     
     /// Minimum time to keep bgReadings and calibrations and treatments
-    static let minimumRetentionPeriodInDays = 90
+    static let minimumRetentionPeriodInDays = 1
 
     /// Maximum time to keep bgReadings and calibrations and treatments
     static let maximumRetentionPeriodInDays = 365

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewController.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewController.swift
@@ -66,7 +66,7 @@ final class SettingsViewController: UIViewController {
         case contactImage
         
         /// housekeeper settings
-        // case housekeeper // let's leave this out for now until an import function is added
+        case housekeeper
         
         /// M5 stack settings
         case M5stack
@@ -113,8 +113,8 @@ final class SettingsViewController: UIViewController {
                 return SettingsViewCalendarEventsSettingsViewModel()
             case .contactImage:
                 return SettingsViewContactImageSettingsViewModel()
-//            case .housekeeper:
-//                return SettingsViewHousekeeperSettingsViewModel(coreDataManager: coreDataManager)
+            case .housekeeper:
+                return SettingsViewHousekeeperSettingsViewModel(coreDataManager: coreDataManager)
             case .trace:
                 return SettingsViewTraceSettingsViewModel()
             case .info:


### PR DESCRIPTION
This allows Nightscout uploads to continue to function when returning to Master mode after a long period of being Follower as per JohanDegraeve/xdripswift#559.